### PR TITLE
Feature/recentee categories

### DIFF
--- a/.env
+++ b/.env
@@ -34,3 +34,7 @@ VITE_GET_DONATION_PREVIEW_LAST_ROUTE="/api/donation/preview/last"
 # Rota de media de doações (GET /media/donation/)
 VITE_GET_MEDIA_DONATION_ROUTE="/media/donation"
 VITE_GET_MEDIA_DONATION_DEFAULT_PHOTO="default.webp"
+
+## Rotas de categorias ###
+# Rota de categorias com contagem de doações disponíveis (GET api/category/donation/available)
+VITE_GET_CATEGORY_DONATION_AVAILABLE_ROUTE="/api/category/donation/available"

--- a/src/components/CategoryCard/CategoryCard.jsx
+++ b/src/components/CategoryCard/CategoryCard.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import clsx from 'clsx';
+import { twMerge } from 'tailwind-merge';
+import { categoryCardStyles, categoryCardIconStyles, categoryCardTitleStyles, categoryCardCountStyles } from './CategoryCard.styles';
+
+export default function CategoryCard({
+    children,
+    title,
+    count,
+    onClick,
+    className,
+    disabled = false,
+    ...rest
+}) {
+    return (
+        <div
+            className={twMerge(clsx(
+                categoryCardStyles({ disabled }),
+                className
+            ))}
+            onClick={disabled ? undefined : onClick}
+            role={onClick && !disabled ? "button" : undefined}
+            tabIndex={onClick && !disabled ? 0 : undefined}
+            onKeyDown={onClick && !disabled ? (e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    onClick(e);
+                }
+            } : undefined}
+            aria-label={onClick && !disabled ? `Categoria ${title} com ${count} itens disponíveis` : undefined}
+            {...rest}
+        >
+            {/* Ícone */}
+            <div className={categoryCardIconStyles()}>
+                {children}
+            </div>
+
+            {/* Título */}
+            <h3 className={categoryCardTitleStyles()}>
+                {title}
+            </h3>
+
+            {/* Contador */}
+            <p className={categoryCardCountStyles()}>
+                {count} {count === 1 ? 'item disponível' : 'itens disponíveis'}
+            </p>
+        </div>
+    );
+}
+
+CategoryCard.propTypes = {
+    children: PropTypes.node.isRequired,
+    title: PropTypes.string.isRequired,
+    count: PropTypes.number.isRequired,
+    onClick: PropTypes.func,
+    className: PropTypes.string,
+    disabled: PropTypes.bool,
+};

--- a/src/components/CategoryCard/CategoryCard.stories.jsx
+++ b/src/components/CategoryCard/CategoryCard.stories.jsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import CategoryCard from './CategoryCard';
+import { FaTshirt, FaBook, FaTv, FaUtensils, FaGamepad, FaCouch, FaBaby, FaMusic } from 'react-icons/fa';
+
+export default {
+  title: 'Components/CategoryCard',
+  component: CategoryCard,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    title: {
+      control: { type: 'text' },
+      description: 'Nome da categoria',
+    },
+    count: {
+      control: { type: 'number' },
+      description: 'Quantidade de itens disponíveis',
+    },
+    disabled: {
+      control: { type: 'boolean' },
+      description: 'Estado desabilitado',
+    },
+    onClick: {
+      action: 'clicked',
+      description: 'Função chamada ao clicar no card',
+    },
+  },
+};
+
+export const Default = {
+  args: {
+    title: 'Roupas',
+    count: 247,
+    disabled: false,
+    children: <FaTshirt />,
+  },
+};
+
+export const SingleItem = {
+  args: {
+    title: 'Livros',
+    count: 1,
+    children: <FaBook />,
+  },
+};
+
+export const HighCount = {
+  args: {
+    title: 'Eletrônicos',
+    count: 1234,
+    children: <FaTv />,
+  },
+};
+
+export const Disabled = {
+  args: {
+    title: 'Utensílios',
+    count: 56,
+    disabled: true,
+    children: <FaUtensils />,
+  },
+};
+
+export const AllCategories = () => (
+  <div className="grid grid-cols-2 md:grid-cols-4 gap-4 p-4">
+    <CategoryCard title="Roupas" count={247}>
+      <FaTshirt />
+    </CategoryCard>
+    <CategoryCard title="Livros" count={89}>
+      <FaBook />
+    </CategoryCard>
+    <CategoryCard title="Eletrônicos" count={156}>
+      <FaTv />
+    </CategoryCard>
+    <CategoryCard title="Utensílios" count={73}>
+      <FaUtensils />
+    </CategoryCard>
+    <CategoryCard title="Jogos" count={42}>
+      <FaGamepad />
+    </CategoryCard>
+    <CategoryCard title="Móveis" count={28}>
+      <FaCouch />
+    </CategoryCard>
+    <CategoryCard title="Infantil" count={134}>
+      <FaBaby />
+    </CategoryCard>
+    <CategoryCard title="Música" count={67}>
+      <FaMusic />
+    </CategoryCard>
+  </div>
+);
+
+export const Interactive = () => {
+  const [selectedCategory, setSelectedCategory] = React.useState(null);
+
+  const categories = [
+    { title: 'Roupas', count: 247, icon: <FaTshirt /> },
+    { title: 'Livros', count: 89, icon: <FaBook /> },
+    { title: 'Eletrônicos', count: 156, icon: <FaTv /> },
+    { title: 'Utensílios', count: 73, icon: <FaUtensils /> },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 gap-4">
+        {categories.map((category) => (
+          <CategoryCard
+            key={category.title}
+            title={category.title}
+            count={category.count}
+            onClick={() => setSelectedCategory(category.title)}
+          >
+            {category.icon}
+          </CategoryCard>
+        ))}
+      </div>
+      {selectedCategory && (
+        <div className="p-4 bg-green-50 rounded-lg text-center">
+          <p className="text-green-800">
+            Categoria selecionada: <strong>{selectedCategory}</strong>
+          </p>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/CategoryCard/CategoryCard.styles.jsx
+++ b/src/components/CategoryCard/CategoryCard.styles.jsx
@@ -1,0 +1,32 @@
+import { cva } from 'class-variance-authority';
+
+export const categoryCardStyles = cva(
+    // Estilo base: card com bordas arredondadas, fundo branco, sombra sutil e efeitos de hover
+    'flex flex-col items-center p-6 bg-white rounded-2xl border border-gray-200 shadow-sm transition-all duration-250 ease-out cursor-pointer hover:shadow-md hover:scale-[1.02] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/50 focus:ring-offset-2',
+    {
+        variants: {
+            disabled: {
+                true: 'opacity-50 cursor-not-allowed hover:shadow-sm hover:scale-100 focus:ring-0',
+                false: '',
+            },
+        },
+        defaultVariants: {
+            disabled: false,
+        },
+    }
+);
+
+export const categoryCardIconStyles = cva(
+    // Container circular para o ícone com fundo verde (cor primária do projeto)
+    'flex items-center justify-center w-16 h-16 mb-4 rounded-full bg-[var(--color-primary)] text-white text-2xl shadow-lg'
+);
+
+export const categoryCardTitleStyles = cva(
+    // Título da categoria
+    'text-lg font-semibold text-gray-900 mb-1 text-center'
+);
+
+export const categoryCardCountStyles = cva(
+    // Texto do contador de itens
+    'text-sm text-gray-600 text-center'
+);

--- a/src/components/CategoryCard/CategoryCard.test.jsx
+++ b/src/components/CategoryCard/CategoryCard.test.jsx
@@ -1,0 +1,214 @@
+import React from 'react';
+import { render, screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { expect, vi, describe, it, beforeEach } from 'vitest';
+import '@testing-library/jest-dom';
+import CategoryCard from './CategoryCard';
+import { FaTshirt, FaBook } from 'react-icons/fa';
+
+describe('CategoryCard component', () => {
+    beforeEach(() => {
+        cleanup();
+    });
+
+    // CT1: Renderização básica
+    it('CT1: renders with required props correctly', () => {
+        render(
+            <CategoryCard title="Roupas" count={247}>
+                <FaTshirt />
+            </CategoryCard>
+        );
+
+        expect(screen.getByText('Roupas')).toBeInTheDocument();
+        expect(screen.getByText('247 itens disponíveis')).toBeInTheDocument();
+        // Verificar se o componente foi renderizado corretamente
+        expect(screen.getByText('Roupas').closest('div')).toBeInTheDocument();
+    });
+
+    // CT2: Singular vs plural no texto do contador
+    it('CT2: displays correct singular/plural text for count', () => {
+        // Teste com 1 item (singular)
+        render(
+            <CategoryCard title="Livros" count={1}>
+                <FaBook />
+            </CategoryCard>
+        );
+        expect(screen.getByText('1 item disponível')).toBeInTheDocument();
+
+        cleanup();
+
+        // Teste com múltiplos itens (plural)
+        render(
+            <CategoryCard title="Roupas" count={247}>
+                <FaTshirt />
+            </CategoryCard>
+        );
+        expect(screen.getByText('247 itens disponíveis')).toBeInTheDocument();
+    });
+
+    // CT3: Renderização do ícone (children)
+    it('CT3: renders icon correctly', () => {
+        render(
+            <CategoryCard title="Roupas" count={247}>
+                <FaTshirt data-testid="tshirt-icon" />
+            </CategoryCard>
+        );
+
+        expect(screen.getByTestId('tshirt-icon')).toBeInTheDocument();
+    });
+
+    // CT4: Funcionalidade de clique
+    it('CT4: calls onClick when clicked', async () => {
+        const user = userEvent.setup();
+        const handleClick = vi.fn();
+
+        render(
+            <CategoryCard title="Roupas" count={247} onClick={handleClick}>
+                <FaTshirt />
+            </CategoryCard>
+        );
+
+        const card = screen.getByRole('button');
+        await user.click(card);
+
+        expect(handleClick).toHaveBeenCalledTimes(1);
+    });
+
+    // CT5: Navegação por teclado
+    it('CT5: supports keyboard navigation', async () => {
+        const user = userEvent.setup();
+        const handleClick = vi.fn();
+
+        render(
+            <CategoryCard title="Roupas" count={247} onClick={handleClick}>
+                <FaTshirt />
+            </CategoryCard>
+        );
+
+        const card = screen.getByRole('button');
+        
+        // Testar Enter
+        await user.tab();
+        expect(card).toHaveFocus();
+        await user.keyboard('{Enter}');
+        expect(handleClick).toHaveBeenCalledTimes(1);
+
+        // Testar Space
+        vi.clearAllMocks();
+        await user.keyboard(' ');
+        expect(handleClick).toHaveBeenCalledTimes(1);
+    });
+
+    // CT6: Estado desabilitado
+    it('CT6: handles disabled state correctly', async () => {
+        const user = userEvent.setup();
+        const handleClick = vi.fn();
+
+        const { container } = render(
+            <CategoryCard title="Roupas" count={247} onClick={handleClick} disabled={true}>
+                <FaTshirt />
+            </CategoryCard>
+        );
+
+        // Quando desabilitado, não tem role="button" 
+        const card = container.firstChild;
+        expect(card).not.toHaveAttribute('role', 'button');
+        expect(card).toHaveClass('opacity-50');
+        expect(card).toHaveClass('cursor-not-allowed');
+
+        // Tentar clicar não deve chamar onClick
+        await user.click(card);
+        expect(handleClick).not.toHaveBeenCalled();
+    });
+
+    // CT7: Sem onClick (modo display apenas)
+    it('CT7: renders without onClick as display only', () => {
+        const { container } = render(
+            <CategoryCard title="Roupas" count={247}>
+                <FaTshirt />
+            </CategoryCard>
+        );
+
+        const card = container.firstChild;
+        expect(card).not.toHaveAttribute('role', 'button');
+        expect(card).not.toHaveAttribute('tabIndex');
+        expect(card).not.toHaveAttribute('aria-label');
+    });
+
+    // CT8: Acessibilidade
+    it('CT8: has proper accessibility attributes when interactive', () => {
+        const handleClick = vi.fn();
+
+        render(
+            <CategoryCard title="Roupas" count={247} onClick={handleClick}>
+                <FaTshirt />
+            </CategoryCard>
+        );
+
+        const card = screen.getByRole('button');
+        expect(card).toHaveAttribute('aria-label', 'Categoria Roupas com 247 itens disponíveis');
+        expect(card).toHaveAttribute('tabIndex', '0');
+    });
+
+    // CT9: Classes CSS customizadas
+    it('CT9: applies custom className', () => {
+        const { container } = render(
+            <CategoryCard title="Roupas" count={247} className="custom-class">
+                <FaTshirt />
+            </CategoryCard>
+        );
+
+        const card = container.firstChild;
+        expect(card).toHaveClass('custom-class');
+    });
+
+    // CT10: Props adicionais
+    it('CT10: forwards additional props', () => {
+        render(
+            <CategoryCard 
+                title="Roupas" 
+                count={247} 
+                data-testid="category-card"
+                id="test-card"
+            >
+                <FaTshirt />
+            </CategoryCard>
+        );
+
+        const card = screen.getByTestId('category-card');
+        expect(card).toHaveAttribute('id', 'test-card');
+    });
+
+    // CT11: Diferentes valores de contador
+    it('CT11: handles different count values', () => {
+        const testCases = [
+            { count: 0, expected: '0 itens disponíveis' },
+            { count: 1, expected: '1 item disponível' },
+            { count: 999, expected: '999 itens disponíveis' },
+            { count: 1000, expected: '1000 itens disponíveis' },
+        ];
+
+        testCases.forEach(({ count, expected }, index) => {
+            cleanup();
+            render(
+                <CategoryCard title={`Test ${index}`} count={count}>
+                    <FaTshirt />
+                </CategoryCard>
+            );
+            expect(screen.getByText(expected)).toBeInTheDocument();
+        });
+    });
+
+    // CT12: Títulos longos
+    it('CT12: handles long titles correctly', () => {
+        const longTitle = 'Categoria com Nome Muito Longo Para Teste';
+        
+        render(
+            <CategoryCard title={longTitle} count={10}>
+                <FaTshirt />
+            </CategoryCard>
+        );
+
+        expect(screen.getByText(longTitle)).toBeInTheDocument();
+    });
+});

--- a/src/components/LastDonationPreview/LastDonationPreview.jsx
+++ b/src/components/LastDonationPreview/LastDonationPreview.jsx
@@ -66,13 +66,13 @@ export default function LastDonationPreview({
 
     const handleDonationClick = (donation) => {
         // Find original donation data
-        const originalDonation = listDonationPreviewDto.find(d => d.donationId === donation.id);
+        const originalDonation = listDonationPreviewDto.find(d => d.donationId === donation.donationId);
         onDonationClick?.(originalDonation);
     };
 
     const handleDonationActionClick = (donation, action) => {
         // Find original donation data
-        const originalDonation = listDonationPreviewDto.find(d => d.donationId === donation.id);
+        const originalDonation = listDonationPreviewDto.find(d => d.donationId === donation.donationId);
         onDonationActionClick?.(originalDonation, action);
     };
 

--- a/src/components/LastDonationPreview/LastDonationPreview.jsx
+++ b/src/components/LastDonationPreview/LastDonationPreview.jsx
@@ -81,7 +81,7 @@ export default function LastDonationPreview({
     }
 
     return (
-        <div
+        <section
             className={twMerge(clsx(
                 lastDonationPreviewContainerStyles(),
                 className
@@ -128,7 +128,7 @@ export default function LastDonationPreview({
                 </Button>
             </div>
 
-        </div>
+        </section>
     );
 }
 

--- a/src/components/LastDonationPreview/LastDonationPreview.test.jsx
+++ b/src/components/LastDonationPreview/LastDonationPreview.test.jsx
@@ -7,7 +7,7 @@ import LastDonationPreview from './LastDonationPreview';
 vi.mock('../DonationPreview/DonationPreview', () => ({
   default: ({ donation, onClick, onActionClick, isDonation, isPublic }) => (
     <div 
-      data-testid={`donation-${donation.id}`}
+      data-testid={`donation-${donation.donationId}`}
       onClick={() => onClick?.(donation)}
     >
       <h3>{donation.title}</h3>
@@ -297,7 +297,7 @@ describe('LastDonationPreview', () => {
     });
   });
 
-  it('não deve mostrar o botão "Ver mais" quando todos os itens estão visíveis', () => {
+  it('deve sempre mostrar o botão "Ver mais" mesmo quando todos os itens estão visíveis', () => {
     render(
       <LastDonationPreview
         data={mockData}
@@ -312,8 +312,8 @@ describe('LastDonationPreview', () => {
     expect(screen.getByTestId('donation-1')).toBeInTheDocument();
     expect(screen.getByTestId('donation-7')).toBeInTheDocument();
     
-    // Não deve mostrar o botão "Ver mais"
-    expect(screen.queryByText('+ Ver mais doações')).not.toBeInTheDocument();
+    // Deve mostrar o botão "Ver mais" para navegar para todas as doações
+    expect(screen.getByText('+ Ver mais doações')).toBeInTheDocument();
   });
 
   it('deve chamar onDonationClick quando uma doação é clicada', () => {

--- a/src/components/TopCategory/TopCategory.jsx
+++ b/src/components/TopCategory/TopCategory.jsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import clsx from 'clsx';
+import { twMerge } from 'tailwind-merge';
+import { topCategoryStyles, topCategoryHeaderStyles, topCategoryTitleStyles, topCategorySubtitleStyles, topCategoryGridStyles } from './TopCategory.styles';
+import CategoryCard from '../CategoryCard/CategoryCard';
+
+export default function TopCategory({
+    categories = [],
+    onCategoryClick,
+    className,
+    title = "Categorias Populares",
+    subtitle = "Encontre doações por categoria",
+    maxCategories = 5,
+    ...rest
+}) {
+    // Limita ao número máximo de categorias (top 5)
+    const displayCategories = categories.slice(0, maxCategories);
+
+    const handleCategoryClick = (category) => {
+        onCategoryClick?.(category);
+    };
+
+    return (
+        <section
+            className={twMerge(clsx(
+                topCategoryStyles(),
+                className
+            ))}
+            aria-label={title}
+            {...rest}
+        >
+            {/* Header com título e subtítulo */}
+            <div className={topCategoryHeaderStyles()}>
+                <h2 className={topCategoryTitleStyles()}>
+                    <span className="mr-2">📱</span>
+                    {title}
+                </h2>
+                <p className={topCategorySubtitleStyles()}>
+                    {subtitle}
+                </p>
+            </div>
+
+            {/* Grid de categorias */}
+            <div className={topCategoryGridStyles()}>
+                {displayCategories.map((category) => (
+                    <CategoryCard
+                        key={category.id || category.title}
+                        title={category.title}
+                        count={category.count}
+                        onClick={() => handleCategoryClick(category)}
+                    >
+                        {category.icon}
+                    </CategoryCard>
+                ))}
+            </div>
+
+            {/* Mensagem quando não há categorias */}
+            {displayCategories.length === 0 && (
+                <div className="text-center py-8">
+                    <p className="text-gray-500">
+                        Nenhuma categoria disponível no momento
+                    </p>
+                </div>
+            )}
+        </section>
+    );
+}
+
+TopCategory.propTypes = {
+    categories: PropTypes.arrayOf(
+        PropTypes.shape({
+            id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+            title: PropTypes.string.isRequired,
+            count: PropTypes.number.isRequired,
+            icon: PropTypes.node.isRequired,
+        })
+    ),
+    onCategoryClick: PropTypes.func,
+    className: PropTypes.string,
+    title: PropTypes.string,
+    subtitle: PropTypes.string,
+    maxCategories: PropTypes.number,
+};

--- a/src/components/TopCategory/TopCategory.jsx
+++ b/src/components/TopCategory/TopCategory.jsx
@@ -105,10 +105,9 @@ export default function TopCategory({
 TopCategory.propTypes = {
     categories: PropTypes.arrayOf(
         PropTypes.shape({
-            id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-            title: PropTypes.string.isRequired,
-            count: PropTypes.number.isRequired,
-            icon: PropTypes.node.isRequired,
+            donationId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+            name: PropTypes.string.isRequired,
+            donationAvailable: PropTypes.number.isRequired,
         })
     ),
     onCategoryClick: PropTypes.func,

--- a/src/components/TopCategory/TopCategory.jsx
+++ b/src/components/TopCategory/TopCategory.jsx
@@ -4,6 +4,11 @@ import clsx from 'clsx';
 import { twMerge } from 'tailwind-merge';
 import { topCategoryStyles, topCategoryHeaderStyles, topCategoryTitleStyles, topCategorySubtitleStyles, topCategoryGridStyles } from './TopCategory.styles';
 import CategoryCard from '../CategoryCard/CategoryCard';
+import { GiClothes } from 'react-icons/gi';
+import { MdDesk, MdPets, MdOutlineApps } from 'react-icons/md';
+import { FaUtensils, FaBookOpen, FaLaptop, FaBowlFood, FaBaby } from 'react-icons/fa6';
+import { TbHorseToy } from 'react-icons/tb';
+import { FaTools } from 'react-icons/fa';
 
 export default function TopCategory({
     categories = [],
@@ -14,8 +19,38 @@ export default function TopCategory({
     maxCategories = 5,
     ...rest
 }) {
-    // Limita ao número máximo de categorias (top 5)
-    const displayCategories = categories.slice(0, maxCategories);
+    const displayCategories = categories
+        .sort((a, b) => b.donationAvailable - a.donationAvailable) // Ordena por donationAvailable (descendente)
+        .slice(0, maxCategories) // Corta os top 5 ou maxCategories
+        .sort((a, b) => a.name.localeCompare(b.name)); // Ordena por name (ascendente)
+
+    const categoryIcon = (categoryName) => {
+        switch (categoryName) {
+            case "Roupas":
+                return <GiClothes />;
+            case "Móveis":
+                return <MdDesk />;
+            case "Utensílios Domésticos":
+                return <FaUtensils />;
+            case "Livros e Material Escolar":
+                return <FaBookOpen />;
+            case "Brinquedos":
+                return <TbHorseToy />;
+            case "Eletrônicos":
+                return <FaLaptop />;
+            case "Pets":
+                return <MdPets />;
+            case "Alimentos":
+                return <FaBowlFood />;
+            case "Itens para Bebês":
+                return <FaBaby />;
+            case "Ferramentas e Materiais":
+                return <FaTools />;
+            default:
+                return <MdOutlineApps />;
+        }
+
+    }
 
     const handleCategoryClick = (category) => {
         onCategoryClick?.(category);
@@ -45,12 +80,12 @@ export default function TopCategory({
             <div className={topCategoryGridStyles()}>
                 {displayCategories.map((category) => (
                     <CategoryCard
-                        key={category.id || category.title}
-                        title={category.title}
-                        count={category.count}
+                        key={category.donationId || category.name}
+                        title={category.name}
+                        count={category.donationAvailable}
                         onClick={() => handleCategoryClick(category)}
                     >
-                        {category.icon}
+                        {categoryIcon(category.name)}
                     </CategoryCard>
                 ))}
             </div>

--- a/src/components/TopCategory/TopCategory.stories.jsx
+++ b/src/components/TopCategory/TopCategory.stories.jsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import TopCategory from './TopCategory';
+import { FaTshirt, FaCouch, FaBook, FaTv, FaBaby, FaUtensils, FaGamepad, FaMusic } from 'react-icons/fa';
+
+export default {
+  title: 'Components/TopCategory',
+  component: TopCategory,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    title: {
+      control: { type: 'text' },
+      description: 'Título da seção',
+    },
+    subtitle: {
+      control: { type: 'text' },
+      description: 'Subtítulo descritivo',
+    },
+    maxCategories: {
+      control: { type: 'number' },
+      description: 'Número máximo de categorias a exibir',
+    },
+    onCategoryClick: {
+      action: 'category-clicked',
+      description: 'Função chamada ao clicar em uma categoria',
+    },
+  },
+};
+
+// Dados de exemplo para as stories
+const mockCategories = [
+  { id: 1, title: 'Roupas', count: 247, icon: <FaTshirt /> },
+  { id: 2, title: 'Móveis', count: 89, icon: <FaCouch /> },
+  { id: 3, title: 'Livros', count: 156, icon: <FaBook /> },
+  { id: 4, title: 'Eletrônicos', count: 43, icon: <FaTv /> },
+  { id: 5, title: 'Infantil', count: 198, icon: <FaBaby /> },
+  { id: 6, title: 'Utensílios', count: 73, icon: <FaUtensils /> },
+  { id: 7, title: 'Jogos', count: 42, icon: <FaGamepad /> },
+  { id: 8, title: 'Música', count: 67, icon: <FaMusic /> },
+];
+
+export const Default = {
+  args: {
+    categories: mockCategories.slice(0, 5),
+    title: "Categorias Populares",
+    subtitle: "Encontre doações por categoria",
+    maxCategories: 5,
+  },
+};
+
+export const Top3Categories = {
+  args: {
+    categories: mockCategories,
+    title: "Top 3 Categorias",
+    subtitle: "As categorias mais procuradas",
+    maxCategories: 3,
+  },
+};
+
+export const AllCategories = {
+  args: {
+    categories: mockCategories,
+    title: "Todas as Categorias",
+    subtitle: "Explore todas as opções disponíveis",
+    maxCategories: 8,
+  },
+};
+
+export const EmptyState = {
+  args: {
+    categories: [],
+    title: "Categorias Populares",
+    subtitle: "Encontre doações por categoria",
+  },
+};
+
+export const SingleCategory = {
+  args: {
+    categories: [mockCategories[0]],
+    title: "Categoria em Destaque",
+    subtitle: "A categoria mais popular do momento",
+  },
+};
+
+export const CustomTitle = {
+  args: {
+    categories: mockCategories.slice(0, 5),
+    title: "🔥 Categorias em Alta",
+    subtitle: "As mais buscadas pelos usuários",
+  },
+};
+
+export const Interactive = () => {
+  const [selectedCategory, setSelectedCategory] = React.useState(null);
+
+  const handleCategoryClick = (category) => {
+    setSelectedCategory(category);
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-4">
+      <TopCategory
+        categories={mockCategories}
+        onCategoryClick={handleCategoryClick}
+        title="Categorias Interativas"
+        subtitle="Clique em uma categoria para ver os detalhes"
+      />
+      
+      {selectedCategory && (
+        <div className="mt-8 max-w-md mx-auto p-6 bg-white rounded-lg shadow-md">
+          <h3 className="text-lg font-semibold mb-2">Categoria Selecionada</h3>
+          <div className="flex items-center gap-3">
+            <div className="w-12 h-12 rounded-full bg-[var(--color-primary)] text-white flex items-center justify-center">
+              {selectedCategory.icon}
+            </div>
+            <div>
+              <p className="font-medium">{selectedCategory.title}</p>
+              <p className="text-sm text-gray-600">
+                {selectedCategory.count} {selectedCategory.count === 1 ? 'item disponível' : 'itens disponíveis'}
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export const WithBackground = () => (
+  <div className="min-h-screen bg-gradient-to-br from-blue-50 to-green-50 p-8">
+    <TopCategory
+      categories={mockCategories}
+      title="Categorias Populares"
+      subtitle="Encontre doações por categoria"
+    />
+  </div>
+);

--- a/src/components/TopCategory/TopCategory.stories.jsx
+++ b/src/components/TopCategory/TopCategory.stories.jsx
@@ -31,14 +31,14 @@ export default {
 
 // Dados de exemplo para as stories
 const mockCategories = [
-  { id: 1, title: 'Roupas', count: 247, icon: <FaTshirt /> },
-  { id: 2, title: 'Móveis', count: 89, icon: <FaCouch /> },
-  { id: 3, title: 'Livros', count: 156, icon: <FaBook /> },
-  { id: 4, title: 'Eletrônicos', count: 43, icon: <FaTv /> },
-  { id: 5, title: 'Infantil', count: 198, icon: <FaBaby /> },
-  { id: 6, title: 'Utensílios', count: 73, icon: <FaUtensils /> },
-  { id: 7, title: 'Jogos', count: 42, icon: <FaGamepad /> },
-  { id: 8, title: 'Música', count: 67, icon: <FaMusic /> },
+  { donationId: 1, name: 'Roupas', donationAvailable: 247 },
+  { donationId: 2, name: 'Móveis', donationAvailable: 89 },
+  { donationId: 3, name: 'Livros e Material Escolar', donationAvailable: 156 },
+  { donationId: 4, name: 'Eletrônicos', donationAvailable: 43 },
+  { donationId: 5, name: 'Itens para Bebês', donationAvailable: 198 },
+  { donationId: 6, name: 'Utensílios Domésticos', donationAvailable: 73 },
+  { donationId: 7, name: 'Brinquedos', donationAvailable: 42 },
+  { donationId: 8, name: 'Alimentos', donationAvailable: 67 },
 ];
 
 export const Default = {

--- a/src/components/TopCategory/TopCategory.styles.jsx
+++ b/src/components/TopCategory/TopCategory.styles.jsx
@@ -2,7 +2,7 @@ import { cva } from 'class-variance-authority';
 
 export const topCategoryStyles = cva(
     // Container principal com fundo transparente e espaçamento
-    'w-full bg-transparent py-8 px-4'
+    'bg-transparent'
 );
 
 export const topCategoryHeaderStyles = cva(
@@ -17,7 +17,8 @@ export const topCategoryTitleStyles = cva(
 
 export const topCategorySubtitleStyles = cva(
     // Subtítulo descritivo
-    'text-gray-600 text-sm md:text-base'
+    // 'text-gray-600 text-lg md:text-base'
+    'text-gray-600 text-lg font-medium'
 );
 
 export const topCategoryGridStyles = cva(

--- a/src/components/TopCategory/TopCategory.styles.jsx
+++ b/src/components/TopCategory/TopCategory.styles.jsx
@@ -1,0 +1,26 @@
+import { cva } from 'class-variance-authority';
+
+export const topCategoryStyles = cva(
+    // Container principal com fundo transparente e espaçamento
+    'w-full bg-transparent py-8 px-4'
+);
+
+export const topCategoryHeaderStyles = cva(
+    // Header centralizado com espaçamento
+    'text-center mb-8'
+);
+
+export const topCategoryTitleStyles = cva(
+    // Título principal com ícone
+    'text-2xl md:text-3xl font-bold text-gray-900 mb-2 flex items-center justify-center'
+);
+
+export const topCategorySubtitleStyles = cva(
+    // Subtítulo descritivo
+    'text-gray-600 text-sm md:text-base'
+);
+
+export const topCategoryGridStyles = cva(
+    // Grid responsivo que exibe categorias em linha horizontal
+    'grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4 md:gap-6 max-w-6xl mx-auto'
+);

--- a/src/components/TopCategory/TopCategory.test.jsx
+++ b/src/components/TopCategory/TopCategory.test.jsx
@@ -8,12 +8,12 @@ import { FaTshirt, FaBook, FaTv, FaCouch, FaBaby } from 'react-icons/fa';
 
 // Dados de teste
 const mockCategories = [
-    { id: 1, title: 'Roupas', count: 247, icon: <FaTshirt /> },
-    { id: 2, title: 'Livros', count: 89, icon: <FaBook /> },
-    { id: 3, title: 'Eletrônicos', count: 156, icon: <FaTv /> },
-    { id: 4, title: 'Móveis', count: 73, icon: <FaCouch /> },
-    { id: 5, title: 'Infantil', count: 134, icon: <FaBaby /> },
-    { id: 6, title: 'Extra', count: 50, icon: <FaTshirt /> }, // Para testar limite
+    { donationId: 1, name: 'Roupas', donationAvailable: 247 },
+    { donationId: 2, name: 'Livros e Material Escolar', donationAvailable: 200 },
+    { donationId: 3, name: 'Eletrônicos', donationAvailable: 156 },
+    { donationId: 4, name: 'Móveis', donationAvailable: 73 },
+    { donationId: 5, name: 'Itens para Bebês', donationAvailable: 134 },
+    { donationId: 6, name: 'Extra', donationAvailable: 50 }, // Para testar limite
 ];
 
 describe('TopCategory component', () => {
@@ -34,10 +34,10 @@ describe('TopCategory component', () => {
         render(<TopCategory categories={mockCategories.slice(0, 3)} />);
 
         expect(screen.getByText('Roupas')).toBeInTheDocument();
-        expect(screen.getByText('Livros')).toBeInTheDocument();
+        expect(screen.getByText('Livros e Material Escolar')).toBeInTheDocument();
         expect(screen.getByText('Eletrônicos')).toBeInTheDocument();
         expect(screen.getByText('247 itens disponíveis')).toBeInTheDocument();
-        expect(screen.getByText('89 itens disponíveis')).toBeInTheDocument();
+        expect(screen.getByText('200 itens disponíveis')).toBeInTheDocument();
     });
 
     // TC3: Limite máximo de categorias (top 5)
@@ -51,7 +51,7 @@ describe('TopCategory component', () => {
 
         // Deve mostrar apenas as primeiras 3
         expect(screen.getByText('Roupas')).toBeInTheDocument();
-        expect(screen.getByText('Livros')).toBeInTheDocument();
+        expect(screen.getByText('Livros e Material Escolar')).toBeInTheDocument();
         expect(screen.getByText('Eletrônicos')).toBeInTheDocument();
         
         // Não deve mostrar a 4ª categoria
@@ -64,10 +64,10 @@ describe('TopCategory component', () => {
 
         // Deve mostrar as primeiras 5
         expect(screen.getByText('Roupas')).toBeInTheDocument();
-        expect(screen.getByText('Livros')).toBeInTheDocument();
+        expect(screen.getByText('Livros e Material Escolar')).toBeInTheDocument();
         expect(screen.getByText('Eletrônicos')).toBeInTheDocument();
         expect(screen.getByText('Móveis')).toBeInTheDocument();
-        expect(screen.getByText('Infantil')).toBeInTheDocument();
+        expect(screen.getByText('Itens para Bebês')).toBeInTheDocument();
         
         // Não deve mostrar a 6ª categoria
         expect(screen.queryByText('Extra')).not.toBeInTheDocument();
@@ -105,7 +105,7 @@ describe('TopCategory component', () => {
         );
 
         const roupasCard = screen.getByRole('button', { name: /categoria roupas/i });
-        const livrosCard = screen.getByRole('button', { name: /categoria livros/i });
+        const livrosCard = screen.getByRole('button', { name: /categoria livros e material escolar/i });
 
         await user.click(roupasCard);
         await user.click(livrosCard);
@@ -181,8 +181,8 @@ describe('TopCategory component', () => {
     // TC12: Categorias com IDs diferentes
     it('TC12: handles categories with different id types', () => {
         const categoriesWithStringIds = [
-            { id: 'cat-1', title: 'Categoria 1', count: 10, icon: <FaTshirt /> },
-            { id: 'cat-2', title: 'Categoria 2', count: 20, icon: <FaBook /> },
+            { donationId: 'cat-1', name: 'Categoria 1', donationAvailable: 10 },
+            { donationId: 'cat-2', name: 'Categoria 2', donationAvailable: 20 },
         ];
 
         render(<TopCategory categories={categoriesWithStringIds} />);
@@ -191,11 +191,11 @@ describe('TopCategory component', () => {
         expect(screen.getByText('Categoria 2')).toBeInTheDocument();
     });
 
-    // TC13: Categorias sem ID (usando title como key)
+    // TC13: Categorias sem ID (usando name como key)
     it('TC13: handles categories without id', () => {
         const categoriesWithoutIds = [
-            { title: 'Sem ID 1', count: 10, icon: <FaTshirt /> },
-            { title: 'Sem ID 2', count: 20, icon: <FaBook /> },
+            { name: 'Sem ID 1', donationAvailable: 10 },
+            { name: 'Sem ID 2', donationAvailable: 20 },
         ];
 
         render(<TopCategory categories={categoriesWithoutIds} />);

--- a/src/components/TopCategory/TopCategory.test.jsx
+++ b/src/components/TopCategory/TopCategory.test.jsx
@@ -1,0 +1,219 @@
+import React from 'react';
+import { render, screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { expect, vi, describe, it, beforeEach } from 'vitest';
+import '@testing-library/jest-dom';
+import TopCategory from './TopCategory';
+import { FaTshirt, FaBook, FaTv, FaCouch, FaBaby } from 'react-icons/fa';
+
+// Dados de teste
+const mockCategories = [
+    { id: 1, title: 'Roupas', count: 247, icon: <FaTshirt /> },
+    { id: 2, title: 'Livros', count: 89, icon: <FaBook /> },
+    { id: 3, title: 'Eletrônicos', count: 156, icon: <FaTv /> },
+    { id: 4, title: 'Móveis', count: 73, icon: <FaCouch /> },
+    { id: 5, title: 'Infantil', count: 134, icon: <FaBaby /> },
+    { id: 6, title: 'Extra', count: 50, icon: <FaTshirt /> }, // Para testar limite
+];
+
+describe('TopCategory component', () => {
+    beforeEach(() => {
+        cleanup();
+    });
+
+    // TC1: Renderização básica
+    it('TC1: renders with default props correctly', () => {
+        render(<TopCategory categories={mockCategories} />);
+
+        expect(screen.getByText('Categorias Populares')).toBeInTheDocument();
+        expect(screen.getByText('Encontre doações por categoria')).toBeInTheDocument();
+    });
+
+    // TC2: Renderização de categorias
+    it('TC2: renders all provided categories', () => {
+        render(<TopCategory categories={mockCategories.slice(0, 3)} />);
+
+        expect(screen.getByText('Roupas')).toBeInTheDocument();
+        expect(screen.getByText('Livros')).toBeInTheDocument();
+        expect(screen.getByText('Eletrônicos')).toBeInTheDocument();
+        expect(screen.getByText('247 itens disponíveis')).toBeInTheDocument();
+        expect(screen.getByText('89 itens disponíveis')).toBeInTheDocument();
+    });
+
+    // TC3: Limite máximo de categorias (top 5)
+    it('TC3: limits categories to maxCategories prop', () => {
+        render(
+            <TopCategory 
+                categories={mockCategories} 
+                maxCategories={3}
+            />
+        );
+
+        // Deve mostrar apenas as primeiras 3
+        expect(screen.getByText('Roupas')).toBeInTheDocument();
+        expect(screen.getByText('Livros')).toBeInTheDocument();
+        expect(screen.getByText('Eletrônicos')).toBeInTheDocument();
+        
+        // Não deve mostrar a 4ª categoria
+        expect(screen.queryByText('Móveis')).not.toBeInTheDocument();
+    });
+
+    // TC4: Limite padrão de 5 categorias
+    it('TC4: shows maximum 5 categories by default', () => {
+        render(<TopCategory categories={mockCategories} />);
+
+        // Deve mostrar as primeiras 5
+        expect(screen.getByText('Roupas')).toBeInTheDocument();
+        expect(screen.getByText('Livros')).toBeInTheDocument();
+        expect(screen.getByText('Eletrônicos')).toBeInTheDocument();
+        expect(screen.getByText('Móveis')).toBeInTheDocument();
+        expect(screen.getByText('Infantil')).toBeInTheDocument();
+        
+        // Não deve mostrar a 6ª categoria
+        expect(screen.queryByText('Extra')).not.toBeInTheDocument();
+    });
+
+    // TC5: Callback onCategoryClick
+    it('TC5: calls onCategoryClick when category is clicked', async () => {
+        const user = userEvent.setup();
+        const handleCategoryClick = vi.fn();
+
+        render(
+            <TopCategory 
+                categories={mockCategories.slice(0, 2)} 
+                onCategoryClick={handleCategoryClick}
+            />
+        );
+
+        const roupasCard = screen.getByRole('button', { name: /categoria roupas/i });
+        await user.click(roupasCard);
+
+        expect(handleCategoryClick).toHaveBeenCalledTimes(1);
+        expect(handleCategoryClick).toHaveBeenCalledWith(mockCategories[0]);
+    });
+
+    // TC6: Múltiplos cliques em categorias diferentes
+    it('TC6: handles multiple category clicks correctly', async () => {
+        const user = userEvent.setup();
+        const handleCategoryClick = vi.fn();
+
+        render(
+            <TopCategory 
+                categories={mockCategories.slice(0, 3)} 
+                onCategoryClick={handleCategoryClick}
+            />
+        );
+
+        const roupasCard = screen.getByRole('button', { name: /categoria roupas/i });
+        const livrosCard = screen.getByRole('button', { name: /categoria livros/i });
+
+        await user.click(roupasCard);
+        await user.click(livrosCard);
+
+        expect(handleCategoryClick).toHaveBeenCalledTimes(2);
+        expect(handleCategoryClick).toHaveBeenNthCalledWith(1, mockCategories[0]);
+        expect(handleCategoryClick).toHaveBeenNthCalledWith(2, mockCategories[1]);
+    });
+
+    // TC7: Título e subtítulo customizados
+    it('TC7: renders custom title and subtitle', () => {
+        const customTitle = 'Minhas Categorias';
+        const customSubtitle = 'Personalizado para você';
+
+        render(
+            <TopCategory 
+                categories={mockCategories.slice(0, 2)}
+                title={customTitle}
+                subtitle={customSubtitle}
+            />
+        );
+
+        expect(screen.getByText(customTitle)).toBeInTheDocument();
+        expect(screen.getByText(customSubtitle)).toBeInTheDocument();
+    });
+
+    // TC8: Estado vazio (sem categorias)
+    it('TC8: shows empty state when no categories provided', () => {
+        render(<TopCategory categories={[]} />);
+
+        expect(screen.getByText('Nenhuma categoria disponível no momento')).toBeInTheDocument();
+        expect(screen.getByText('Categorias Populares')).toBeInTheDocument(); // Título ainda aparece
+    });
+
+    // TC9: Classes CSS customizadas
+    it('TC9: applies custom className', () => {
+        const { container } = render(
+            <TopCategory 
+                categories={mockCategories.slice(0, 2)}
+                className="custom-class"
+            />
+        );
+
+        expect(container.firstChild).toHaveClass('custom-class');
+    });
+
+    // TC10: Props adicionais
+    it('TC10: forwards additional props', () => {
+        render(
+            <TopCategory 
+                categories={mockCategories.slice(0, 2)}
+                data-testid="top-category"
+                id="test-id"
+            />
+        );
+
+        const component = screen.getByTestId('top-category');
+        expect(component).toHaveAttribute('id', 'test-id');
+    });
+
+    // TC11: Sem callback onCategoryClick
+    it('TC11: works without onCategoryClick callback', async () => {
+        const user = userEvent.setup();
+
+        render(<TopCategory categories={mockCategories.slice(0, 2)} />);
+
+        const roupasCard = screen.getByRole('button', { name: /categoria roupas/i });
+        
+        // Não deve lançar erro ao clicar
+        await expect(user.click(roupasCard)).resolves.not.toThrow();
+    });
+
+    // TC12: Categorias com IDs diferentes
+    it('TC12: handles categories with different id types', () => {
+        const categoriesWithStringIds = [
+            { id: 'cat-1', title: 'Categoria 1', count: 10, icon: <FaTshirt /> },
+            { id: 'cat-2', title: 'Categoria 2', count: 20, icon: <FaBook /> },
+        ];
+
+        render(<TopCategory categories={categoriesWithStringIds} />);
+
+        expect(screen.getByText('Categoria 1')).toBeInTheDocument();
+        expect(screen.getByText('Categoria 2')).toBeInTheDocument();
+    });
+
+    // TC13: Categorias sem ID (usando title como key)
+    it('TC13: handles categories without id', () => {
+        const categoriesWithoutIds = [
+            { title: 'Sem ID 1', count: 10, icon: <FaTshirt /> },
+            { title: 'Sem ID 2', count: 20, icon: <FaBook /> },
+        ];
+
+        render(<TopCategory categories={categoriesWithoutIds} />);
+
+        expect(screen.getByText('Sem ID 1')).toBeInTheDocument();
+        expect(screen.getByText('Sem ID 2')).toBeInTheDocument();
+    });
+
+    // TC14: Estrutura semântica correta
+    it('TC14: has proper semantic structure', () => {
+        render(<TopCategory categories={mockCategories.slice(0, 3)} />);
+
+        // Deve ser uma section
+        const section = screen.getByRole('region');
+        expect(section.tagName).toBe('SECTION');
+
+        // Deve ter título h2
+        const heading = screen.getByRole('heading', { level: 2 });
+        expect(heading).toHaveTextContent('Categorias Populares');
+    });
+});

--- a/src/components/UserMenu/UserMenu.test.jsx
+++ b/src/components/UserMenu/UserMenu.test.jsx
@@ -196,7 +196,7 @@ describe("UserMenu component", () => {
     const trigger = screen.getByTestId("user-menu-trigger");
     expect(trigger).toHaveAttribute("aria-expanded", "false");
     expect(trigger).toHaveAttribute("aria-haspopup", "menu");
-    expect(trigger).toHaveAttribute("aria-label", "Menu de opções para Maria Silva");
+    expect(trigger).toHaveAttribute("aria-label", "Menu de opções para Maria");
   });
 
   //CT9: Testar fechamento do menu ao selecionar uma opção

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,11 +1,14 @@
 import NavBar from "../components/NavBar";
 import { useEffect, useState } from "react";
 import LastDonationPreview from "../components/LastDonationPreview/LastDonationPreview";
+import TopCategory from "../components/TopCategory/TopCategory";
 import donationService from "../services/donation/donationService";
+import categoryService from "../services/category/categoryService";
 
 export default function Home (){
 
     const [lastDonations, setLastDonations] = useState(null);
+    const [categories, setCategories] = useState([]);
 
     const fetchLastDonations = async () => {
         try {
@@ -16,18 +19,33 @@ export default function Home (){
         }
     };
 
+    const fetchCategories = async () => {
+        try {
+            const categories = await categoryService.GetCategoriesWithDonationAvailable();
+            setCategories(categories);
+        } catch (error) {
+            console.error("Error fetching categories:", error);
+        }   
+    };
+
     useEffect(() => {
         fetchLastDonations();
+        fetchCategories();
     }, []);
 
     return (
-        <div className="bg-slate-100 p-16">
+        <div className="bg-slate-100 p-16 space-y-16">
             <LastDonationPreview
                 data={lastDonations}
                 itemsPerPage={6}
                 onDonationClick={(donationId) => console.log("Clicked donation:", donationId)}
                 onDonationActionClick={(donationId) => console.log("Action clicked for donation:", donationId)}
                 onLoadMore={() => console.log("Load more donations")}
+            />
+            <TopCategory
+                categories={categories}
+                onCategoryClick={(category) => console.log("Clicked category:", category)}
+                // className="mt-16"
             />
         </div>
     )

--- a/src/services/category/categoryService.js
+++ b/src/services/category/categoryService.js
@@ -1,0 +1,20 @@
+import apiService from "../apiService/apiService";
+import VCategoryDonationAvailable from "./dto/vCategoryDonationAvailable";
+
+const GET_CATEGORY_DONATION_AVAILABLE_ROUTE = import.meta.env.VITE_GET_CATEGORY_DONATION_AVAILABLE_ROUTE || "/api/category/donation/available";
+
+class CategoryService {
+
+    async GetCategoriesWithDonationAvailable() {
+        try {
+            let categoriesData = await apiService.get(GET_CATEGORY_DONATION_AVAILABLE_ROUTE);
+            return categoriesData.map(cat => VCategoryDonationAvailable.fromJson(cat));
+        } catch (error) {
+            console.error(error);
+            return Promise.reject(new Error(error.message));
+        }
+    }
+}
+
+const categoryService = new CategoryService();
+export default categoryService;

--- a/src/services/category/dto/vCategoryDonationAvailable.js
+++ b/src/services/category/dto/vCategoryDonationAvailable.js
@@ -1,0 +1,16 @@
+import BaseDTO from "../../util/baseDTO";
+
+export default class VCategoryDonationAvailable extends BaseDTO {
+    constructor() {
+        super();
+        this.categoryId = null;
+        this.name = null;
+        this.donationAvailable = null;
+    }
+
+    static schema = {
+        categoryId: ['number'],
+        name: ['string'],
+        donationAvailable: ['number']
+    };
+}


### PR DESCRIPTION
This pull request introduces a new reusable `CategoryCard` component for displaying categories with available donation counts, including full styling, accessibility, Storybook stories, and comprehensive tests. It also adds the `TopCategory` component to showcase popular categories, updates environment variables for category API routes, and improves the `LastDonationPreview` component and its tests for consistency and accessibility.

**New Category Components**

* Added the `CategoryCard` component with accessible interactions, custom styling using CVA and Tailwind, and support for icons, click, and disabled states. [[1]](diffhunk://#diff-11cd2d0db01ae070cc216ae59943e237568adace70c7b34f512b8854f3c77da1R1-R59) [[2]](diffhunk://#diff-24cd40d2a231941dfc60b6313a28d7eaa457a3311752b284a9b8482853c96dd6R1-R32)
* Created Storybook stories and interactive demos for `CategoryCard` to facilitate documentation and design review.
* Implemented a full test suite for `CategoryCard` covering rendering, accessibility, interaction, and edge cases.

**Top Categories Feature**

* Introduced the `TopCategory` component to display the most popular categories, integrating `CategoryCard` and dynamic icon selection, with sorting and fallback messaging.

**API and Environment Updates**

* Added a new environment variable `VITE_GET_CATEGORY_DONATION_AVAILABLE_ROUTE` for fetching categories with available donation counts. (.env)

**Last Donation Preview Improvements**

* Fixed data mapping in `LastDonationPreview` to use `donationId` consistently, improved semantic markup by changing the main container from `div` to `section`, and updated related tests for accuracy and accessibility. [[1]](diffhunk://#diff-9fac60164e18c23f056d357b5d2a69a83aa2f56f0a0bc32cc448880b5b5adf2dL69-R75) [[2]](diffhunk://#diff-9fac60164e18c23f056d357b5d2a69a83aa2f56f0a0bc32cc448880b5b5adf2dL84-R84) [[3]](diffhunk://#diff-9fac60164e18c23f056d357b5d2a69a83aa2f56f0a0bc32cc448880b5b5adf2dL131-R131) [[4]](diffhunk://#diff-744e4d30974af357417bb1f21ea87bdff449e54b1024ccff1dce70630c9f6e3dL10-R10) [[5]](diffhunk://#diff-744e4d30974af357417bb1f21ea87bdff449e54b1024ccff1dce70630c9f6e3dL300-R300) [[6]](diffhunk://#diff-744e4d30974af357417bb1f21ea87bdff449e54b1024ccff1dce70630c9f6e3dL315-R316)